### PR TITLE
Adding Mnemonic and Pseudoinstructions section

### DIFF
--- a/zawrs.adoc
+++ b/zawrs.adoc
@@ -8,6 +8,13 @@ sum of the `time` and `htimedelta` CSRs when `V=1` (similar to `stimecmp` and
 `vstimecmp` respectively), for the wait. On RV32 systems, a deadline cannot be 
 specified as the `rs1` is limited to 32-bit.
 
+*Mnemonic:*
+wrs _rs1_
+
+*Pseudoinstructions:*
+wrs &#8594; wrs zero
+
+*Encoding:*
 [wavedrom, , ]
 ....
 {reg: [


### PR DESCRIPTION
This patch adds a mnemonic and pseudo instruction section
similar to what other recently ratified specifications (e.g. bitmanip)
have.

Note, that the `wrs` pseudo-instruction allows omitting the register
operand if no timeout is given.