### PR TITLE
Clarify mstatus.TW behavior for other privilege modes

### DIFF
--- a/zawrs.adoc
+++ b/zawrs.adoc
@@ -36,9 +36,9 @@ stall and complete execution for any reason.
 for resuming execution on a pending  interrupt.
 
 When the `TW` (Timeout Wait) bit in `mstatus` is set and `WRS.NTO` is executed
-in any privilege mode other than M mode, and it does not complete within an implementation-specific
-bounded time limit, the `WRS.NTO` instruction will cause an illegal instruction
-exception.
+in any privilege mode other than M mode, and it does not complete within an
+implementation-specific bounded time limit, the `WRS.NTO` instruction will cause
+an illegal instruction exception.
 
 When executing in VS or VU mode, if the `VTW` bit is set in `hstatus`, the 
 `TW` bit in `mstatus` is clear, and the `WRS.NTO` does not complete within an 

--- a/zawrs.adoc
+++ b/zawrs.adoc
@@ -36,7 +36,7 @@ stall and complete execution for any reason.
 for resuming execution on a pending  interrupt.
 
 When the `TW` (Timeout Wait) bit in `mstatus` is set and `WRS.NTO` is executed
-in S or U  mode, and it does not complete within an implementation-specific 
+in any privilege mode other than M mode, and it does not complete within an implementation-specific
 bounded time limit, the `WRS.NTO` instruction will cause an illegal instruction
 exception.
 


### PR DESCRIPTION
The spec does not say what should happen when `mstatus.TW=1` in HS, VS, or VU modes.

Based on the purpose of `mstatus.TW` I can assume the intended behavior, but the spec should be clear about this.
