### PR TITLE
Possible typo

### DIFF
--- a/header.adoc
+++ b/header.adoc
@@ -92,7 +92,7 @@ task at a future time or otherwise place an upper bound on the wait. To support
 such use cases a second instruction `WRS.STO` (WRS-with-short-timeout) is 
 provided that works like `WRS.NTO` but bounds the stall duration to an 
 implementation-define short timeout such that the stall is terminated on the 
-timeout if no other conditions have to occurred to terminate the stall. The 
+timeout if no other conditions have occurred to terminate the stall. The 
 program using this instruction may then determine if its deadline has been 
 reached.
 


### PR DESCRIPTION
> bounds the stall duration to an 
implementation-define short timeout such that the stall is terminated on the 
timeout if no other conditions have to occurred to terminate the stall.

Shouldn't `have to occured` be `have occured` here ?